### PR TITLE
Fix possible data race in mock server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# IDE
+.idea/

--- a/jsonrpc/mockserver.go
+++ b/jsonrpc/mockserver.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 
 	"github.com/ethereum/go-ethereum/log"
 )
 
 type MockJSONRPCServer struct {
+	mu             sync.Mutex
 	Handlers       map[string]func(req *JSONRPCRequest) (interface{}, error)
 	RequestCounter map[string]int
 	server         *httptest.Server
@@ -61,7 +63,10 @@ func (s *MockJSONRPCServer) handleHTTPRequest(w http.ResponseWriter, req *http.R
 		return
 	}
 
+	s.mu.Lock()
 	s.RequestCounter[jsonReq.Method]++
+	s.mu.Unlock()
+
 	rawRes, err := jsonRPCHandler(jsonReq)
 	if err != nil {
 		returnError(jsonReq.ID, err)

--- a/jsonrpc/mockserver_test.go
+++ b/jsonrpc/mockserver_test.go
@@ -19,3 +19,36 @@ func TestErrorResponse(t *testing.T) {
 	assert.Equal(t, 123, res.Error.Code)
 	assert.Equal(t, "test", res.Error.Message)
 }
+
+func TestMockJSONRPCServer_IncrementRequestCounter(t *testing.T) {
+	srv := NewMockJSONRPCServer()
+	srv.RequestCounter.Store("EXISTING", 0)
+
+	testCases := []struct {
+		name                 string
+		method               string
+		expectedRequestCount int
+	}{
+		{
+			name:                 "Existing value in map",
+			method:               "EXISTING",
+			expectedRequestCount: 1,
+		},
+		{
+			name:                 "Non existing value in map",
+			method:               "UNKNOWN",
+			expectedRequestCount: 1,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			srv.IncrementRequestCounter(tt.method)
+
+			value, ok := srv.RequestCounter.Load(tt.method)
+
+			assert.Equal(t, true, ok)
+			assert.Equal(t, value, tt.expectedRequestCount)
+		})
+	}
+}


### PR DESCRIPTION
## mev-boost is having data races because of concurrent read and write on request counter

### Description

[mev-boost uses the jsonprc mock server in its tests](https://github.com/flashbots/mev-boost/blob/79f11e0712e9e2b895133c4600d0b922cfbecebd/server/e2e_test.go#L317).
Unfortunately, the `RequestCounter` member is not protected from concurrent read and write.

A data race happended while I was testing the project with `-race` option.

You can learn more about the issue [here](https://github.com/flashbots/mev-boost/issues/116)

I've added a mutex to prevent such behavior to happen.