### PR TITLE
Remove Makefile rule & fix typo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 GIT_VER := $(shell git describe --tags --always --dirty="-dev")
 
-all: clean build
-
 v:
 	@echo "Version: ${GIT_VER}"
 

--- a/jsonrpc/mockserver.go
+++ b/jsonrpc/mockserver.go
@@ -72,7 +72,7 @@ func (s *MockJSONRPCServer) handleHTTPRequest(w http.ResponseWriter, req *http.R
 	w.WriteHeader(http.StatusOK)
 	resBytes, err := json.Marshal(rawRes)
 	if err != nil {
-		log.Error("error mashalling rawRes", "err", err, "data", rawRes)
+		log.Error("error marshalling rawRes", "err", err, "data", rawRes)
 		return
 	}
 


### PR DESCRIPTION
This PR will fix two minor problems:

* Remove `all` recipe in Makefile.
  * The `clean` & `build` recipes do not exist.
  * There is nothing to build, so it should just be removed.
* Fix a simple typo in mock server.