### PR TITLE
Logging enhancements

### DIFF
--- a/envflag/envflag.go
+++ b/envflag/envflag.go
@@ -1,0 +1,54 @@
+// Package envflag is a wrapper for stdlib's flag that adds the environment
+// variables as additional source of the values for flags.
+package envflag
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/flashbots/go-utils/truthy"
+)
+
+// Bool is a convenience wrapper for boolean flag that picks its default value
+// from the environment variable.
+func Bool(name string, defaultValue bool, usage string) *bool {
+	value := defaultValue
+	env := flagToEnv(name)
+	if raw := os.Getenv(env); raw != "" {
+		value = truthy.Is(raw)
+	}
+	return flag.Bool(name, value, usage+fmt.Sprintf(" (env \"%s\")", env))
+}
+
+// Int is a convenience wrapper for integer flag that picks its default value
+// from the environment variable.
+func Int(name string, defaultValue int, usage string) *int {
+	value := defaultValue
+	env := flagToEnv(name)
+	if raw := os.Getenv(env); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil {
+			value = parsed
+		}
+	}
+	return flag.Int(name, value, usage+fmt.Sprintf(" (env \"%s\")", env))
+}
+
+// String is a convenience wrapper for string flag that picks its default value
+// from the environment variable.
+func String(name, defaultValue, usage string) *string {
+	value := defaultValue
+	env := flagToEnv(name)
+	if raw := os.Getenv(env); raw != "" {
+		value = raw
+	}
+	return flag.String(name, value, usage+fmt.Sprintf(" (env \"%s\")", env))
+}
+
+func flagToEnv(flag string) string {
+	return strings.ToUpper(
+		strings.ReplaceAll(flag, "-", "_"),
+	)
+}

--- a/envflag/envflag.go
+++ b/envflag/envflag.go
@@ -13,27 +13,75 @@ import (
 )
 
 // Bool is a convenience wrapper for boolean flag that picks its default value
-// from the environment variable.
-func Bool(name string, defaultValue bool, usage string) *bool {
+// from the environment variable. It returns error if the environment variable's
+// value can not be resolved into definitive `true` or `false`.
+func Bool(name string, defaultValue bool, usage string) (*bool, error) {
+	var err error
 	value := defaultValue
 	env := flagToEnv(name)
 	if raw := os.Getenv(env); raw != "" {
-		value = truthy.Is(raw)
+		if pValue, pErr := truthy.Is(raw); pErr == nil {
+			value = pValue
+		} else {
+			err = fmt.Errorf("invalid boolean value \"%s\" for environment variable %s: %w", raw, env, pErr)
+		}
 	}
-	return flag.Bool(name, value, usage+fmt.Sprintf(" (env \"%s\")", env))
+	return flag.Bool(name, value, usage+fmt.Sprintf(" (env \"%s\")", env)), err
+}
+
+// MustBool handles error (if any) returned by Bool according to the behaviour
+// configured by `flag.CommandLine.ErrorHandling()` by either ignoring it,
+// exiting the process with status code 2, or panicking.
+func MustBool(name string, defaultValue bool, usage string) *bool {
+	res, err := Bool(name, defaultValue, usage)
+	if err != nil {
+		switch flag.CommandLine.ErrorHandling() {
+		case flag.ContinueOnError:
+			// continue
+		case flag.ExitOnError:
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		case flag.PanicOnError:
+			panic(err)
+		}
+	}
+	return res
 }
 
 // Int is a convenience wrapper for integer flag that picks its default value
-// from the environment variable.
-func Int(name string, defaultValue int, usage string) *int {
+// from the environment variable. It returns error if the environment variable's
+// value can not be parsed into integer.
+func Int(name string, defaultValue int, usage string) (*int, error) {
+	var err error
 	value := defaultValue
 	env := flagToEnv(name)
 	if raw := os.Getenv(env); raw != "" {
-		if parsed, err := strconv.Atoi(raw); err == nil {
-			value = parsed
+		if pValue, pErr := strconv.Atoi(raw); pErr == nil {
+			value = pValue
+		} else {
+			err = fmt.Errorf("invalid integer value \"%s\" for environment variable %s: %w", raw, env, pErr)
 		}
 	}
-	return flag.Int(name, value, usage+fmt.Sprintf(" (env \"%s\")", env))
+	return flag.Int(name, value, usage+fmt.Sprintf(" (env \"%s\")", env)), err
+}
+
+// MustInt handles error (if any) returned by Int according to the behaviour
+// configured by `flag.CommandLine.ErrorHandling()` by either ignoring it,
+// exiting the process with status code 2, or panicking.
+func MustInt(name string, defaultValue int, usage string) *int {
+	res, err := Int(name, defaultValue, usage)
+	if err != nil {
+		switch flag.CommandLine.ErrorHandling() {
+		case flag.ContinueOnError:
+			// continue
+		case flag.ExitOnError:
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		case flag.PanicOnError:
+			panic(err)
+		}
+	}
+	return res
 }
 
 // String is a convenience wrapper for string flag that picks its default value

--- a/envflag/envflag_test.go
+++ b/envflag/envflag_test.go
@@ -1,0 +1,267 @@
+package envflag_test
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/flashbots/go-utils/envflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBool(t *testing.T) {
+	const name = "bool-var"
+	const env = "BOOL_VAR"
+
+	args := make([]string, len(os.Args))
+	copy(os.Args, args)
+	defer func() {
+		os.Args = make([]string, len(args))
+		copy(args, os.Args)
+	}()
+
+	{ // cli: absent;  env: absent;  default: false
+		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+		os.Args = []string{"envflag.test"}
+		os.Unsetenv(env)
+		f := envflag.Bool(name, false, "")
+		assert.NotNil(t, f)
+		flag.Parse()
+		assert.False(t, *f)
+	}
+	{ // cli: absent;  env: absent;  default: true
+		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+		os.Args = []string{"envflag.test"}
+		os.Unsetenv(env)
+		f := envflag.Bool(name, true, "")
+		assert.NotNil(t, f)
+		flag.Parse()
+		assert.True(t, *f)
+	}
+	{ // cli: absent;  env: false;  default: false
+		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+		os.Args = []string{"envflag.test"}
+		t.Setenv(env, "0")
+		f := envflag.Bool(name, false, "")
+		assert.NotNil(t, f)
+		flag.Parse()
+		assert.False(t, *f)
+	}
+	{ // cli: absent;  env: false;  default: true
+		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+		os.Args = []string{"envflag.test"}
+		t.Setenv(env, "0")
+		f := envflag.Bool(name, true, "")
+		assert.NotNil(t, f)
+		flag.Parse()
+		assert.False(t, *f)
+	}
+	{ // cli: absent;  env: true;  default: false
+		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+		os.Args = []string{"envflag.test"}
+		t.Setenv(env, "1")
+		f := envflag.Bool(name, false, "")
+		assert.NotNil(t, f)
+		flag.Parse()
+		assert.True(t, *f)
+	}
+	{ // cli: absent;  env: true;  default: true
+		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+		os.Args = []string{"envflag.test"}
+		t.Setenv(env, "1")
+		f := envflag.Bool(name, true, "")
+		assert.NotNil(t, f)
+		flag.Parse()
+		assert.True(t, *f)
+	}
+
+	{ // cli: false;  env: absent;  default: false
+		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+		os.Args = []string{"envflag.test", "-" + name + "=false"}
+		os.Unsetenv(env)
+		f := envflag.Bool(name, false, "")
+		assert.NotNil(t, f)
+		flag.Parse()
+		assert.False(t, *f)
+	}
+	{ // cli: false;  env: absent;  default: true
+		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+		os.Args = []string{"envflag.test", "-" + name + "=false"}
+		os.Unsetenv(env)
+		f := envflag.Bool(name, true, "")
+		assert.NotNil(t, f)
+		flag.Parse()
+		assert.False(t, *f)
+	}
+	{ // cli: false;  env: false;  default: false
+		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+		os.Args = []string{"envflag.test", "-" + name + "=false"}
+		t.Setenv(env, "0")
+		f := envflag.Bool(name, false, "")
+		assert.NotNil(t, f)
+		flag.Parse()
+		assert.False(t, *f)
+	}
+	{ // cli: false;  env: false;  default: true
+		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+		os.Args = []string{"envflag.test", "-" + name + "=false"}
+		t.Setenv(env, "0")
+		f := envflag.Bool(name, true, "")
+		assert.NotNil(t, f)
+		flag.Parse()
+		assert.False(t, *f)
+	}
+	{ // cli: false;  env: true;  default: false
+		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+		os.Args = []string{"envflag.test", "-" + name + "=false"}
+		t.Setenv(env, "1")
+		f := envflag.Bool(name, false, "")
+		assert.NotNil(t, f)
+		flag.Parse()
+		assert.False(t, *f)
+	}
+	{ // cli: false;  env: true;  default: true
+		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+		os.Args = []string{"envflag.test", "-" + name + "=false"}
+		t.Setenv(env, "1")
+		f := envflag.Bool(name, true, "")
+		assert.NotNil(t, f)
+		flag.Parse()
+		assert.False(t, *f)
+	}
+
+	{ // cli: true;  env: absent;  default: false
+		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+		os.Args = []string{"envflag.test", "-" + name}
+		os.Unsetenv(env)
+		f := envflag.Bool(name, false, "")
+		assert.NotNil(t, f)
+		flag.Parse()
+		assert.True(t, *f)
+	}
+	{ // cli: true;  env: absent;  default: true
+		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+		os.Args = []string{"envflag.test", "-" + name}
+		os.Unsetenv(env)
+		f := envflag.Bool(name, true, "")
+		assert.NotNil(t, f)
+		flag.Parse()
+		assert.True(t, *f)
+	}
+	{ // cli: true;  env: false;  default: false
+		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+		os.Args = []string{"envflag.test", "-" + name}
+		t.Setenv(env, "0")
+		f := envflag.Bool(name, false, "")
+		assert.NotNil(t, f)
+		flag.Parse()
+		assert.True(t, *f)
+	}
+	{ // cli: true;  env: false;  default: true
+		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+		os.Args = []string{"envflag.test", "-" + name}
+		t.Setenv(env, "0")
+		f := envflag.Bool(name, true, "")
+		assert.NotNil(t, f)
+		flag.Parse()
+		assert.True(t, *f)
+	}
+	{ // cli: true;  env: true;  default: false
+		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+		os.Args = []string{"envflag.test", "-" + name}
+		t.Setenv(env, "1")
+		f := envflag.Bool(name, false, "")
+		assert.NotNil(t, f)
+		flag.Parse()
+		assert.True(t, *f)
+	}
+	{ // cli: true;  env: true;  default: true
+		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+		os.Args = []string{"envflag.test", "-" + name}
+		t.Setenv(env, "1")
+		f := envflag.Bool(name, true, "")
+		assert.NotNil(t, f)
+		flag.Parse()
+		assert.True(t, *f)
+	}
+}
+
+func TestInt(t *testing.T) {
+	const name = "int-var"
+	const env = "INT_VAR"
+
+	args := make([]string, len(os.Args))
+	copy(os.Args, args)
+	defer func() {
+		os.Args = make([]string, len(args))
+		copy(args, os.Args)
+	}()
+
+	{ // cli: absent;  env: absent;  default: 42
+		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+		os.Args = []string{"envflag.test"}
+		os.Unsetenv(env)
+		f := envflag.Int(name, 42, "")
+		assert.NotNil(t, f)
+		flag.Parse()
+		assert.Equal(t, 42, *f)
+	}
+	{ // cli: absent;  env: 42;  default: 0
+		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+		os.Args = []string{"envflag.test"}
+		t.Setenv(env, "42")
+		f := envflag.Int(name, 0, "")
+		assert.NotNil(t, f)
+		flag.Parse()
+		assert.Equal(t, 42, *f)
+	}
+	{ // cli: 42;  env: 21;  default: 0
+		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+		os.Args = []string{"envflag.test", "-" + name, "42"}
+		t.Setenv(env, "21")
+		f := envflag.Int(name, 0, "")
+		assert.NotNil(t, f)
+		flag.Parse()
+		assert.Equal(t, 42, *f)
+	}
+}
+
+func TestString(t *testing.T) {
+	const name = "string-var"
+	const env = "STRING_VAR"
+
+	args := make([]string, len(os.Args))
+	copy(os.Args, args)
+	defer func() {
+		os.Args = make([]string, len(args))
+		copy(args, os.Args)
+	}()
+
+	{ // cli: absent;  env: absent;  default: 42
+		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+		os.Args = []string{"envflag.test"}
+		os.Unsetenv(env)
+		f := envflag.String(name, "42", "")
+		assert.NotNil(t, f)
+		flag.Parse()
+		assert.Equal(t, "42", *f)
+	}
+	{ // cli: absent;  env: 42;  default: 0
+		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+		os.Args = []string{"envflag.test"}
+		t.Setenv(env, "42")
+		f := envflag.String(name, "0", "")
+		assert.NotNil(t, f)
+		flag.Parse()
+		assert.Equal(t, "42", *f)
+	}
+	{ // cli: 42;  env: 21;  default: 0
+		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+		os.Args = []string{"envflag.test", "-" + name, "42"}
+		t.Setenv(env, "21")
+		f := envflag.String(name, "0", "")
+		assert.NotNil(t, f)
+		flag.Parse()
+		assert.Equal(t, "42", *f)
+	}
+}

--- a/envflag/envflag_test.go
+++ b/envflag/envflag_test.go
@@ -24,7 +24,7 @@ func TestBool(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
 		os.Args = []string{"envflag.test"}
 		os.Unsetenv(env)
-		f := envflag.Bool(name, false, "")
+		f := envflag.MustBool(name, false, "")
 		assert.NotNil(t, f)
 		flag.Parse()
 		assert.False(t, *f)
@@ -33,7 +33,7 @@ func TestBool(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
 		os.Args = []string{"envflag.test"}
 		os.Unsetenv(env)
-		f := envflag.Bool(name, true, "")
+		f := envflag.MustBool(name, true, "")
 		assert.NotNil(t, f)
 		flag.Parse()
 		assert.True(t, *f)
@@ -42,7 +42,7 @@ func TestBool(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
 		os.Args = []string{"envflag.test"}
 		t.Setenv(env, "0")
-		f := envflag.Bool(name, false, "")
+		f := envflag.MustBool(name, false, "")
 		assert.NotNil(t, f)
 		flag.Parse()
 		assert.False(t, *f)
@@ -51,7 +51,7 @@ func TestBool(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
 		os.Args = []string{"envflag.test"}
 		t.Setenv(env, "0")
-		f := envflag.Bool(name, true, "")
+		f := envflag.MustBool(name, true, "")
 		assert.NotNil(t, f)
 		flag.Parse()
 		assert.False(t, *f)
@@ -60,7 +60,7 @@ func TestBool(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
 		os.Args = []string{"envflag.test"}
 		t.Setenv(env, "1")
-		f := envflag.Bool(name, false, "")
+		f := envflag.MustBool(name, false, "")
 		assert.NotNil(t, f)
 		flag.Parse()
 		assert.True(t, *f)
@@ -69,7 +69,7 @@ func TestBool(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
 		os.Args = []string{"envflag.test"}
 		t.Setenv(env, "1")
-		f := envflag.Bool(name, true, "")
+		f := envflag.MustBool(name, true, "")
 		assert.NotNil(t, f)
 		flag.Parse()
 		assert.True(t, *f)
@@ -79,7 +79,7 @@ func TestBool(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
 		os.Args = []string{"envflag.test", "-" + name + "=false"}
 		os.Unsetenv(env)
-		f := envflag.Bool(name, false, "")
+		f := envflag.MustBool(name, false, "")
 		assert.NotNil(t, f)
 		flag.Parse()
 		assert.False(t, *f)
@@ -88,7 +88,7 @@ func TestBool(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
 		os.Args = []string{"envflag.test", "-" + name + "=false"}
 		os.Unsetenv(env)
-		f := envflag.Bool(name, true, "")
+		f := envflag.MustBool(name, true, "")
 		assert.NotNil(t, f)
 		flag.Parse()
 		assert.False(t, *f)
@@ -97,7 +97,7 @@ func TestBool(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
 		os.Args = []string{"envflag.test", "-" + name + "=false"}
 		t.Setenv(env, "0")
-		f := envflag.Bool(name, false, "")
+		f := envflag.MustBool(name, false, "")
 		assert.NotNil(t, f)
 		flag.Parse()
 		assert.False(t, *f)
@@ -106,7 +106,7 @@ func TestBool(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
 		os.Args = []string{"envflag.test", "-" + name + "=false"}
 		t.Setenv(env, "0")
-		f := envflag.Bool(name, true, "")
+		f := envflag.MustBool(name, true, "")
 		assert.NotNil(t, f)
 		flag.Parse()
 		assert.False(t, *f)
@@ -115,7 +115,7 @@ func TestBool(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
 		os.Args = []string{"envflag.test", "-" + name + "=false"}
 		t.Setenv(env, "1")
-		f := envflag.Bool(name, false, "")
+		f := envflag.MustBool(name, false, "")
 		assert.NotNil(t, f)
 		flag.Parse()
 		assert.False(t, *f)
@@ -124,7 +124,7 @@ func TestBool(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
 		os.Args = []string{"envflag.test", "-" + name + "=false"}
 		t.Setenv(env, "1")
-		f := envflag.Bool(name, true, "")
+		f := envflag.MustBool(name, true, "")
 		assert.NotNil(t, f)
 		flag.Parse()
 		assert.False(t, *f)
@@ -134,7 +134,7 @@ func TestBool(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
 		os.Args = []string{"envflag.test", "-" + name}
 		os.Unsetenv(env)
-		f := envflag.Bool(name, false, "")
+		f := envflag.MustBool(name, false, "")
 		assert.NotNil(t, f)
 		flag.Parse()
 		assert.True(t, *f)
@@ -143,7 +143,7 @@ func TestBool(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
 		os.Args = []string{"envflag.test", "-" + name}
 		os.Unsetenv(env)
-		f := envflag.Bool(name, true, "")
+		f := envflag.MustBool(name, true, "")
 		assert.NotNil(t, f)
 		flag.Parse()
 		assert.True(t, *f)
@@ -152,7 +152,7 @@ func TestBool(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
 		os.Args = []string{"envflag.test", "-" + name}
 		t.Setenv(env, "0")
-		f := envflag.Bool(name, false, "")
+		f := envflag.MustBool(name, false, "")
 		assert.NotNil(t, f)
 		flag.Parse()
 		assert.True(t, *f)
@@ -161,7 +161,7 @@ func TestBool(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
 		os.Args = []string{"envflag.test", "-" + name}
 		t.Setenv(env, "0")
-		f := envflag.Bool(name, true, "")
+		f := envflag.MustBool(name, true, "")
 		assert.NotNil(t, f)
 		flag.Parse()
 		assert.True(t, *f)
@@ -170,7 +170,7 @@ func TestBool(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
 		os.Args = []string{"envflag.test", "-" + name}
 		t.Setenv(env, "1")
-		f := envflag.Bool(name, false, "")
+		f := envflag.MustBool(name, false, "")
 		assert.NotNil(t, f)
 		flag.Parse()
 		assert.True(t, *f)
@@ -179,7 +179,7 @@ func TestBool(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
 		os.Args = []string{"envflag.test", "-" + name}
 		t.Setenv(env, "1")
-		f := envflag.Bool(name, true, "")
+		f := envflag.MustBool(name, true, "")
 		assert.NotNil(t, f)
 		flag.Parse()
 		assert.True(t, *f)
@@ -201,7 +201,7 @@ func TestInt(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
 		os.Args = []string{"envflag.test"}
 		os.Unsetenv(env)
-		f := envflag.Int(name, 42, "")
+		f := envflag.MustInt(name, 42, "")
 		assert.NotNil(t, f)
 		flag.Parse()
 		assert.Equal(t, 42, *f)
@@ -210,7 +210,7 @@ func TestInt(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
 		os.Args = []string{"envflag.test"}
 		t.Setenv(env, "42")
-		f := envflag.Int(name, 0, "")
+		f := envflag.MustInt(name, 0, "")
 		assert.NotNil(t, f)
 		flag.Parse()
 		assert.Equal(t, 42, *f)
@@ -219,7 +219,7 @@ func TestInt(t *testing.T) {
 		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
 		os.Args = []string{"envflag.test", "-" + name, "42"}
 		t.Setenv(env, "21")
-		f := envflag.Int(name, 0, "")
+		f := envflag.MustInt(name, 0, "")
 		assert.NotNil(t, f)
 		flag.Parse()
 		assert.Equal(t, 42, *f)

--- a/examples/httplogger/main.go
+++ b/examples/httplogger/main.go
@@ -2,17 +2,17 @@ package main
 
 import (
 	"errors"
-	"fmt"
+	"flag"
 	"net/http"
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/flashbots/go-utils/httplogger"
+	"github.com/flashbots/go-utils/logutils"
 	"go.uber.org/zap"
 )
 
 var (
 	listenAddr = "localhost:8124"
-	// logJSON    = os.Getenv("LOG_JSON") == "1"
 )
 
 func HelloHandler(w http.ResponseWriter, r *http.Request) {
@@ -21,7 +21,8 @@ func HelloHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func ErrorHandler(w http.ResponseWriter, r *http.Request) {
-	log.Error("this is an error", "err", errors.New("testError"))
+	l := logutils.ZapFromRequest(r)
+	l.Error("this is an error", zap.Error(errors.New("testError")))
 	http.Error(w, "this is an error", http.StatusInternalServerError)
 }
 
@@ -29,29 +30,26 @@ func PanicHandler(w http.ResponseWriter, r *http.Request) {
 	panic("foo!")
 }
 
-func getZapLogger() *zap.SugaredLogger {
-	// logger, _ := zap.NewDevelopment()
-	logger, _ := zap.NewProduction()
-	log := logger.Sugar()
-	return log
-}
-
 func main() {
-	// logFormat := log.TerminalFormat(true)
-	// if logJSON {
-	// 	logFormat = log.JSONFormat()
-	// }
+	logLevel := flag.String("log-level", "info", "Log level")
+	logDev := flag.Bool("log-dev", false, "Log in development mode")
+	flag.Parse()
 
-	// log.Root().SetHandler(log.LvlFilterHandler(log.LvlDebug, log.StreamHandler(os.Stderr, logFormat)))
+	l := logutils.GetZapLogger(
+		logutils.LogDevMode(*logDev),
+		logutils.LogLevel(*logLevel),
+	)
+	defer logutils.FlushZap(l)
 
-	fmt.Println("Webserver running at", listenAddr)
+	l.Info("Webserver running at " + listenAddr)
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/hello", HelloHandler)
 	mux.HandleFunc("/error", ErrorHandler)
 	mux.HandleFunc("/panic", PanicHandler)
-	loggedRouter := httplogger.LoggingMiddlewareZap(getZapLogger(), mux)
+	loggedRouter := httplogger.LoggingMiddlewareZap(l, mux)
+
 	if err := http.ListenAndServe(listenAddr, loggedRouter); err != nil {
 		log.Crit("webserver failed", "err", err)
 	}
-
 }

--- a/examples/httplogger/main.go
+++ b/examples/httplogger/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/flashbots/go-utils/envflag"
 	"github.com/flashbots/go-utils/httplogger"
 	"github.com/flashbots/go-utils/logutils"
 	"go.uber.org/zap"
@@ -31,11 +32,11 @@ func PanicHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	logLevel := flag.String("log-level", "info", "Log level")
-	logDev := flag.Bool("log-dev", false, "Log in development mode")
+	logLevel := envflag.String("log-level", "info", "Log level")
+	logDev := envflag.MustBool("log-dev", false, "Log in development mode")
 	flag.Parse()
 
-	l := logutils.GetZapLogger(
+	l := logutils.MustGetZapLogger(
 		logutils.LogDevMode(*logDev),
 		logutils.LogLevel(*logLevel),
 	)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/ethereum/go-ethereum v1.10.25
+	github.com/google/uuid v1.2.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.0
 	go.uber.org/atomic v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,7 @@ github.com/golang-jwt/jwt/v4 v4.3.0 h1:kHL1vqdqWNfATmA0FNMdmZNMyZI1U6O31X4rlIPoB
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/go-bexpr v0.1.10 h1:9kuI5PFotCboP3dkDYFr/wi0gg0QVbSNz5oFRpxn4uE=

--- a/httplogger/httplogger.go
+++ b/httplogger/httplogger.go
@@ -117,7 +117,10 @@ func LoggingMiddlewareZap(logger *zap.Logger, next http.Handler) http.Handler {
 		_uuid := [16]byte(uuid.New())
 		httpRequestID := base64.RawStdEncoding.EncodeToString(_uuid[:])
 
-		l := logger.With(zap.String("httpRequestID", httpRequestID))
+		l := logger.With(
+			zap.String("httpRequestID", httpRequestID),
+			zap.String("logType", "activity"),
+		)
 		r = logutils.RequestWithZap(r, l)
 
 		// Handle panics
@@ -143,9 +146,11 @@ func LoggingMiddlewareZap(logger *zap.Logger, next http.Handler) http.Handler {
 
 		// Passing request stats both in-message (for the human reader)
 		// as well as inside the structured log (for the machine parser)
-		l.Info(fmt.Sprintf("Handled HTTP request: %s %s %d", r.Method, r.URL.EscapedPath(), wrapped.status),
+		logger.Info(fmt.Sprintf("%s: %s %s %d", r.URL.Scheme, r.Method, r.URL.EscapedPath(), wrapped.status),
 			zap.Int("durationMs", int(time.Since(start).Milliseconds())),
 			zap.Int("status", wrapped.status),
+			zap.String("httpRequestID", httpRequestID),
+			zap.String("logType", "access"),
 			zap.String("method", r.Method),
 			zap.String("path", r.URL.EscapedPath()),
 		)

--- a/httplogger/httplogger.go
+++ b/httplogger/httplogger.go
@@ -144,7 +144,7 @@ func LoggingMiddlewareZap(logger *zap.Logger, next http.Handler) http.Handler {
 		// Passing request stats both in-message (for the human reader)
 		// as well as inside the structured log (for the machine parser)
 		l.Info(fmt.Sprintf("Handled HTTP request: %s %s %d", r.Method, r.URL.EscapedPath(), wrapped.status),
-			zap.Duration("duration", time.Since(start)),
+			zap.Int("durationMs", int(time.Since(start).Milliseconds())),
 			zap.Int("status", wrapped.status),
 			zap.String("method", r.Method),
 			zap.String("path", r.URL.EscapedPath()),

--- a/httplogger/httplogger.go
+++ b/httplogger/httplogger.go
@@ -2,12 +2,15 @@
 package httplogger
 
 import (
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"runtime/debug"
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/flashbots/go-utils/logutils"
+	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	"go.uber.org/zap"
 )
@@ -108,36 +111,43 @@ func LoggingMiddlewareLogrus(logger *logrus.Entry, next http.Handler) http.Handl
 }
 
 // LoggingMiddlewareZap logs the incoming HTTP request & its duration.
-func LoggingMiddlewareZap(logger *zap.SugaredLogger, next http.Handler) http.Handler {
-	return http.HandlerFunc(
-		func(w http.ResponseWriter, r *http.Request) {
-			defer func() {
-				if err := recover(); err != nil {
-					w.WriteHeader(http.StatusInternalServerError)
+func LoggingMiddlewareZap(logger *zap.Logger, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Generate request ID (`base64` to shorten its string representation)
+		_uuid := [16]byte(uuid.New())
+		httpRequestID := base64.RawStdEncoding.EncodeToString(_uuid[:])
 
-					method := ""
-					url := ""
-					if r != nil {
-						method = r.Method
-						url = r.URL.EscapedPath()
-					}
+		l := logger.With(zap.String("httpRequestID", httpRequestID))
+		r = logutils.RequestWithZap(r, l)
 
-					logger.With(
-						"err", err,
-						"trace", string(debug.Stack()),
-						"method", r.Method,
-					).Errorf("http request panic: %s %s", method, url)
+		// Handle panics
+		defer func() {
+			if msg := recover(); msg != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				var method, url string
+				if r != nil {
+					method = r.Method
+					url = r.URL.EscapedPath()
 				}
-			}()
-			start := time.Now()
-			wrapped := wrapResponseWriter(w)
-			next.ServeHTTP(wrapped, r)
-			logger.With(
-				"status", wrapped.status,
-				"method", r.Method,
-				"path", r.URL.EscapedPath(),
-				"duration", fmt.Sprintf("%f", time.Since(start).Seconds()),
-			).Infof("http: %s %s %d", r.Method, r.URL.EscapedPath(), wrapped.status)
-		},
-	)
+				l.Error("HTTP request handler panicked",
+					zap.Any("error", msg),
+					zap.String("method", method),
+					zap.String("url", url),
+				)
+			}
+		}()
+
+		start := time.Now()
+		wrapped := wrapResponseWriter(w)
+		next.ServeHTTP(w, r)
+
+		// Passing request stats both in-message (for the human reader)
+		// as well as inside the structured log (for the machine parser)
+		l.Info(fmt.Sprintf("Handled HTTP request: %s %s %d", r.Method, r.URL.EscapedPath(), wrapped.status),
+			zap.Duration("duration", time.Since(start)),
+			zap.Int("status", wrapped.status),
+			zap.String("method", r.Method),
+			zap.String("path", r.URL.EscapedPath()),
+		)
+	})
 }

--- a/logutils/context.go
+++ b/logutils/context.go
@@ -1,0 +1,26 @@
+// Package logutils implements helpers for logging.
+package logutils
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+)
+
+type contextKey string
+
+const loggerContextKey contextKey = "logger"
+
+// ContextWithZap returns a copy of parent context injected with corresponding
+// zap logger.
+func ContextWithZap(parent context.Context, logger *zap.Logger) context.Context {
+	return context.WithValue(parent, loggerContextKey, logger)
+}
+
+// ZapFromContext retrieves the zap logger passed with a context.
+func ZapFromContext(ctx context.Context) *zap.Logger {
+	if l, found := ctx.Value(loggerContextKey).(*zap.Logger); found {
+		return l
+	}
+	return zap.L()
+}

--- a/logutils/flush.go
+++ b/logutils/flush.go
@@ -1,0 +1,31 @@
+package logutils
+
+import (
+	"errors"
+	"html"
+	"io/fs"
+	"log"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// FlushZap triggers the Sync() on the logger. In case of an error, it will log it
+// using the logger from standard library.
+func FlushZap(logger *zap.Logger) {
+	if err := logger.Sync(); err != nil {
+		// Workaround for `inappropriate ioctl for device` or `invalid argument` errors
+		// See: https://github.com/uber-go/zap/issues/880#issuecomment-731261906
+		var pathErr *fs.PathError
+		if errors.As(err, &pathErr) {
+			if pathErr.Path == "/dev/stderr" && pathErr.Op == "sync" {
+				return
+			}
+		}
+		log.Printf(
+			"{\"level\":\"error\",\"ts\":\"%s\",\"msg\":\"Failed to sync the logger\",\"error\":\"%s\"}\n",
+			time.Now().Format(time.RFC3339),
+			html.EscapeString(err.Error()),
+		)
+	}
+}

--- a/logutils/getlogger.go
+++ b/logutils/getlogger.go
@@ -1,0 +1,89 @@
+package logutils
+
+import (
+	"fmt"
+	"strings"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+type loggerConfig struct {
+	devMode bool
+	level   string
+}
+
+// LogConfigOption allows to fine-tune the configuration of the logger.
+type LogConfigOption = func(*loggerConfig)
+
+// LogDevMode tells the logger to work in the development mode.
+func LogDevMode(devMode bool) LogConfigOption {
+	return func(lc *loggerConfig) {
+		lc.devMode = devMode
+	}
+}
+
+// LogLevel sets the desired level of logging.
+func LogLevel(level string) LogConfigOption {
+	return func(lc *loggerConfig) {
+		lc.level = level
+	}
+}
+
+// GetZapLogger returns a logger created according to `log-level` and
+// `log-dev` command-line switches.
+//
+// Note: this method defines two flags, `log-level` and `log-dev`; redefining
+// them in your main app will cause panic.
+func GetZapLogger(options ...LogConfigOption) *zap.Logger {
+	cfg := &loggerConfig{
+		devMode: false,
+		level:   zap.InfoLevel.String(),
+	}
+
+	for _, o := range options {
+		o(cfg)
+	}
+
+	var config zap.Config
+	if cfg.devMode {
+		config = zap.NewDevelopmentConfig()
+	} else {
+		config = zap.NewProductionConfig()
+	}
+
+	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+
+	level, levelErr := zap.ParseAtomicLevel(cfg.level)
+	if levelErr != nil {
+		level = zap.NewAtomicLevel()
+	}
+	config.Level = level
+
+	l, buildErr := config.Build()
+	if buildErr != nil {
+		l = zap.L()
+	}
+
+	if levelErr != nil {
+		valid := "'" + strings.Join([]string{
+			zap.DebugLevel.String(),
+			zap.InfoLevel.String(),
+			zap.WarnLevel.String(),
+			zap.ErrorLevel.String(),
+			zap.FatalLevel.String(),
+			zap.PanicLevel.String(),
+		}, "', '") + "'"
+		l.Warn(
+			fmt.Sprintf("Invalid log-level was specified (defaulted to '%s', valid levels are: %s)", config.Level.String(), valid),
+			zap.Error(levelErr),
+		)
+	}
+	if buildErr != nil {
+		l.Error("Failed to build the logger with desired configuration",
+			zap.Error(buildErr),
+		)
+	}
+
+	return l
+}

--- a/logutils/httprequest.go
+++ b/logutils/httprequest.go
@@ -1,0 +1,20 @@
+package logutils
+
+import (
+	"net/http"
+
+	"go.uber.org/zap"
+)
+
+// RequestWithZap returns a shallow copy of parent request with context
+// being supplemented with corresponding zap logger.
+func RequestWithZap(parent *http.Request, logger *zap.Logger) *http.Request {
+	return parent.WithContext(
+		ContextWithZap(parent.Context(), logger),
+	)
+}
+
+// ZapFromRequest retrieves the zap logger passed with request's context.
+func ZapFromRequest(request *http.Request) *zap.Logger {
+	return ZapFromContext(request.Context())
+}

--- a/truthy/truthy.go
+++ b/truthy/truthy.go
@@ -1,35 +1,48 @@
 // Package truthy implements helpers to test the truthy-ness of the values.
 package truthy
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
-// nos is the list of well-known representations of `false`.
-//
-// Of course, if the user passes some weird string like `faooooolse` that would
-// render it to be considered unjustifiably truthy. However we just can not deal
-// with every possible corner case. So, let's just keep things simple.
-//
-// If need be after all, we can always extend this list (but maybe implement
-// binary search if it grows too big).
-var nos = [...]string{
-	"",
-	"0",
-	"f",
-	"false",
-	"n",
-	"no",
+var isTruthy = map[string]bool{
+	// truthy
+	"1":    true,
+	"t":    true,
+	"true": true,
+	"y":    true,
+	"yes":  true,
+	// non-truthy
+	"":      false,
+	"0":     false,
+	"f":     false,
+	"false": false,
+	"n":     false,
+	"no":    false,
 }
 
 // Is returns `false` if the argument sounds like "false" (empty string, "0",
 // "f", "false", and so on), and `true` otherwise.
-func Is(val string) bool {
-	val = strings.ToLower(val)
-
-	for _, no := range nos {
-		if val == no {
-			return false
-		}
+func Is(val string) (bool, error) {
+	if res, known := isTruthy[strings.ToLower(val)]; known {
+		return res, nil
 	}
+	return false, fmt.Errorf("can not resolve truthy-ness of \"%s\"", val)
+}
 
-	return true
+// TrueOnError returns true if err is not nil, otherwise it returns res.
+func TrueOnError(res bool, err error) bool {
+	if err != nil {
+		return true
+	}
+	return res
+}
+
+// FalseOnError returns false if err is not nil, otherwise it returns res.
+func FalseOnError(res bool, err error) bool {
+	if err != nil {
+		return false
+	}
+	return res
 }

--- a/truthy/truthy.go
+++ b/truthy/truthy.go
@@ -1,0 +1,35 @@
+// Package truthy implements helpers to test the truthy-ness of the values.
+package truthy
+
+import "strings"
+
+// nos is the list of well-known representations of `false`.
+//
+// Of course, if the user passes some weird string like `faooooolse` that would
+// render it to be considered unjustifiably truthy. However we just can not deal
+// with every possible corner case. So, let's just keep things simple.
+//
+// If need be after all, we can always extend this list (but maybe implement
+// binary search if it grows too big).
+var nos = [...]string{
+	"",
+	"0",
+	"f",
+	"false",
+	"n",
+	"no",
+}
+
+// Is returns `false` if the argument sounds like "false" (empty string, "0",
+// "f", "false", and so on), and `true` otherwise.
+func Is(val string) bool {
+	val = strings.ToLower(val)
+
+	for _, no := range nos {
+		if val == no {
+			return false
+		}
+	}
+
+	return true
+}

--- a/truthy/truthy_test.go
+++ b/truthy/truthy_test.go
@@ -1,0 +1,39 @@
+package truthy_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/flashbots/go-utils/truthy"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIs(t *testing.T) {
+	{ // truthy values
+		for _, y := range []string{
+			"1",
+			"t",
+			"T",
+			"true",
+			"True",
+			"Y",
+			"yes",
+		} {
+			assert.True(t, truthy.Is(y), fmt.Sprintf("Value '%s' must render as truthy", y))
+		}
+	}
+	{ // falsy values
+		for _, n := range []string{
+			"",
+			"0",
+			"f",
+			"F",
+			"false",
+			"False",
+			"N",
+			"no",
+		} {
+			assert.False(t, truthy.Is(n), fmt.Sprintf("Value '%s' must render as falsy", n))
+		}
+	}
+}

--- a/truthy/truthy_test.go
+++ b/truthy/truthy_test.go
@@ -19,7 +19,11 @@ func TestIs(t *testing.T) {
 			"Y",
 			"yes",
 		} {
-			assert.True(t, truthy.Is(y), fmt.Sprintf("Value '%s' must render as truthy", y))
+			assert.True(
+				t,
+				truthy.FalseOnError(truthy.Is(y)),
+				fmt.Sprintf("Value '%s' must render as truthy", y),
+			)
 		}
 	}
 	{ // falsy values
@@ -33,7 +37,11 @@ func TestIs(t *testing.T) {
 			"N",
 			"no",
 		} {
-			assert.False(t, truthy.Is(n), fmt.Sprintf("Value '%s' must render as falsy", n))
+			assert.False(
+				t,
+				truthy.TrueOnError(truthy.Is(n)),
+				fmt.Sprintf("Value '%s' must render as falsy", n),
+			)
 		}
 	}
 }


### PR DESCRIPTION
This PR is a follow up to https://github.com/flashbots/go-template/pull/10.

It implements the following:

- A helper `truthy.Is()` that returns `true` if the string passed to it looks like truthy (for example: `"yes"`, `"true"`, and so on).
- A set of wrappers for `flag` package (`envflag.Bool()`, `envflag.Int()`, `envflag.String()`, ) that create flags with default values derived from the environment variables.
- Some helper utils for logging:
  - `logutils.ContextWithLogger()` injects a logger into the context, while `logutils.FromContext()` retrieves it.
  - Similarly, `logutils.RequestWithLogger()` creates a shallow copy of `http.Request` such that its context has the logger injected.  Its counterpart is `logutils.FromRequest()`.
  - `logutils.Flush()` implements the final log flusher (to be used with `defer`) that reports any errors that occur at that stage.
  - `logutils.GetZapLogger()` generates a global zap logger based on the configuration parameters passed to the app with command-line switches or with environment variables.
- And finally, it updates `httplogger.LoggingMiddlewareZap()` to use the above helpers, and to:
  - Inject a logger into the request's context.
  - Generate unique `httpRequestID` that will be added to the request's context logger (so that every log line produced by it would mention that ID).