### PR TITLE
[feat] Export available log levels

### DIFF
--- a/logutils/levels.go
+++ b/logutils/levels.go
@@ -1,0 +1,13 @@
+package logutils
+
+import "go.uber.org/zap"
+
+var Levels = []string{
+	zap.DebugLevel.String(),
+	zap.InfoLevel.String(),
+	zap.WarnLevel.String(),
+	zap.ErrorLevel.String(),
+	zap.DPanicLevel.String(),
+	zap.PanicLevel.String(),
+	zap.FatalLevel.String(),
+}


### PR DESCRIPTION
Let's export a helper variable with all valid log levels (to make the code in `go-template` simpler).