### PR TITLE
envflag nil guard on MustBool and MustInt

### DIFF
--- a/envflag/envflag.go
+++ b/envflag/envflag.go
@@ -45,6 +45,9 @@ func MustBool(name string, defaultValue bool, usage string) *bool {
 			panic(err)
 		}
 	}
+	if res == nil { // should never happen, guard added for NilAway
+		panic(fmt.Sprintf("MustBool res for '%s' is nil", name))
+	}
 	return res
 }
 
@@ -81,6 +84,11 @@ func MustInt(name string, defaultValue int, usage string) *int {
 			panic(err)
 		}
 	}
+
+	if res == nil { // should never happen, guard added for NilAway
+		panic(fmt.Sprintf("MustInt res for '%s' is nil", name))
+	}
+
 	return res
 }
 


### PR DESCRIPTION
for compatibility with https://github.com/uber-go/nilaway

otherwise complains:

```bash
-> envflag/envflag.go:48:9: result 0 of `Bool()` lacking guarding; returned from `MustBool()` in position 0
```