### PR TITLE
jsonrpc: support multiple parameters

### DIFF
--- a/jsonrpc/mockserver_test.go
+++ b/jsonrpc/mockserver_test.go
@@ -12,7 +12,7 @@ func TestErrorResponse(t *testing.T) {
 		return nil, &JSONRPCError{Code: 123, Message: "test"}
 	}
 
-	req := NewJSONRPCRequest(1, "eth_call", "0xabc")
+	req := NewJSONRPCRequest(1, "eth_call", []interface{}{"0xabc"})
 	res, err := SendJSONRPCRequest(*req, server.URL)
 	assert.Nil(t, err, err)
 	assert.NotNil(t, res.Error)

--- a/jsonrpc/request.go
+++ b/jsonrpc/request.go
@@ -15,11 +15,11 @@ type JSONRPCRequest struct {
 	Version string        `json:"jsonrpc,omitempty"`
 }
 
-func NewJSONRPCRequest(id interface{}, method string, args interface{}) *JSONRPCRequest {
+func NewJSONRPCRequest(id interface{}, method string, args []interface{}) *JSONRPCRequest {
 	return &JSONRPCRequest{
 		ID:      id,
 		Method:  method,
-		Params:  []interface{}{args},
+		Params:  args,
 		Version: "2.0",
 	}
 }
@@ -45,7 +45,7 @@ func SendJSONRPCRequest(req JSONRPCRequest, url string) (res *JSONRPCResponse, e
 }
 
 // SendNewJSONRPCRequest constructs a request and sends it to the URL
-func SendNewJSONRPCRequest(id interface{}, method string, args interface{}, url string) (res *JSONRPCResponse, err error) {
+func SendNewJSONRPCRequest(id interface{}, method string, args []interface{}, url string) (res *JSONRPCResponse, err error) {
 	req := NewJSONRPCRequest(id, method, args)
 	return SendJSONRPCRequest(*req, url)
 }

--- a/jsonrpc/request_test.go
+++ b/jsonrpc/request_test.go
@@ -18,7 +18,7 @@ func setupMockServer() string {
 func TestSendJsonRpcRequest(t *testing.T) {
 	addr := setupMockServer()
 
-	req := NewJSONRPCRequest(1, "eth_call", "0xabc")
+	req := NewJSONRPCRequest(1, "eth_call", []interface{}{"0xabc"})
 	res, err := SendJSONRPCRequest(*req, addr)
 	assert.Nil(t, err, err)
 
@@ -28,7 +28,7 @@ func TestSendJsonRpcRequest(t *testing.T) {
 	assert.Equal(t, "0x12345", *reply)
 
 	// Test an unknown RPC method
-	req2 := NewJSONRPCRequest(2, "unknown", "foo")
+	req2 := NewJSONRPCRequest(2, "unknown", []interface{}{"foo"})
 	res2, err := SendJSONRPCRequest(*req2, addr)
 	assert.Nil(t, err, err)
 	assert.NotNil(t, res2.Error)
@@ -37,13 +37,13 @@ func TestSendJsonRpcRequest(t *testing.T) {
 func TestSendJSONRPCRequestAndParseResult(t *testing.T) {
 	addr := setupMockServer()
 
-	req := NewJSONRPCRequest(1, "eth_call", "0xabc")
+	req := NewJSONRPCRequest(1, "eth_call", []interface{}{"0xabc"})
 	res := new(string)
 	err := SendJSONRPCRequestAndParseResult(*req, addr, res)
 	assert.Nil(t, err, err)
 	assert.Equal(t, "0x12345", *res)
 
-	req2 := NewJSONRPCRequest(2, "unknown", "foo")
+	req2 := NewJSONRPCRequest(2, "unknown", []interface{}{"foo"})
 	res2 := new(string)
 	err = SendJSONRPCRequestAndParseResult(*req2, addr, res2)
 	assert.NotNil(t, err, err)


### PR DESCRIPTION
I put this client to use, but I found that it didn't seem to support passing multiple parameters to an RPC method, so I changed it to support that.

I realize that this is breaking a public interface, but I wanted to put up the PR as a discussion starter if nothing else.