### PR TITLE
Versioned bundles support and proper identifiers for `v2`

### DIFF
--- a/rpctypes/types.go
+++ b/rpctypes/types.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"hash"
 	"sort"
 
@@ -28,13 +29,16 @@ const (
 	BundleTxLimit     = 100
 	MevBundleTxLimit  = 50
 	MevBundleMaxDepth = 1
+	BundleVersionV1   = "v1"
+	BundleVersionV2   = "v2"
 )
 
 var (
-	ErrBundleNoTxs          = errors.New("bundle with no txs")
-	ErrBundleTooManyTxs     = errors.New("too many txs in bundle")
-	ErrMevBundleUnmatchedTx = errors.New("mev bundle with unmatched tx")
-	ErrMevBundleTooDeep     = errors.New("mev bundle too deep")
+	ErrBundleNoTxs              = errors.New("bundle with no txs")
+	ErrBundleTooManyTxs         = errors.New("too many txs in bundle")
+	ErrMevBundleUnmatchedTx     = errors.New("mev bundle with unmatched tx")
+	ErrMevBundleTooDeep         = errors.New("mev bundle too deep")
+	ErrUnsupportedBundleVersion = errors.New("unsupported bundle version")
 )
 
 type EthSendBundleArgs struct {
@@ -44,6 +48,7 @@ type EthSendBundleArgs struct {
 	MaxTimestamp      *uint64         `json:"maxTimestamp,omitempty"`
 	RevertingTxHashes []common.Hash   `json:"revertingTxHashes,omitempty"`
 	ReplacementUUID   *string         `json:"replacementUuid,omitempty"`
+	Version           *string         `json:"version,omitempty"`
 
 	// fields available only when receiving from the Flashbots or other builders, not users
 	ReplacementNonce *uint64         `json:"replacementNonce,omitempty"`
@@ -186,6 +191,23 @@ func (b *EthSendBundleArgs) UniqueKey() uuid.UUID {
 		_ = binary.Write(hash, binary.LittleEndian, *b.ReplacementNonce)
 	}
 
+	sort.Slice(b.DroppingTxHashes, func(i, j int) bool {
+		return bytes.Compare(b.DroppingTxHashes[i][:], b.DroppingTxHashes[j][:]) <= 0
+	})
+	for _, txHash := range b.DroppingTxHashes {
+		_, _ = hash.Write(txHash.Bytes())
+	}
+	if b.RefundPercent != nil {
+		_ = binary.Write(hash, binary.LittleEndian, *b.RefundPercent)
+	}
+
+	if b.RefundRecipient != nil {
+		_, _ = hash.Write(b.RefundRecipient.Bytes())
+	}
+	for _, txHash := range b.RefundTxHashes {
+		_, _ = hash.Write([]byte(txHash))
+	}
+
 	if b.SigningAddress != nil {
 		_, _ = hash.Write(b.SigningAddress.Bytes())
 	}
@@ -211,19 +233,114 @@ func (b *EthSendBundleArgs) Validate() (common.Hash, uuid.UUID, error) {
 	}
 	hashBytes := hasher.Sum(nil)
 
-	// then compute the uuid
-	var buf []byte
-	buf = binary.AppendVarint(buf, int64(blockNumber))
-	buf = append(buf, hashBytes...)
-	sort.Slice(b.RevertingTxHashes, func(i, j int) bool {
-		return bytes.Compare(b.RevertingTxHashes[i][:], b.RevertingTxHashes[j][:]) <= 0
-	})
-	for _, txHash := range b.RevertingTxHashes {
-		buf = append(buf, txHash[:]...)
+	if b.Version == nil || *b.Version == BundleVersionV1 {
+		// then compute the uuid
+		var buf []byte
+		buf = binary.AppendVarint(buf, int64(blockNumber))
+		buf = append(buf, hashBytes...)
+		sort.Slice(b.RevertingTxHashes, func(i, j int) bool {
+			return bytes.Compare(b.RevertingTxHashes[i][:], b.RevertingTxHashes[j][:]) <= 0
+		})
+		for _, txHash := range b.RevertingTxHashes {
+			buf = append(buf, txHash[:]...)
+		}
+		return common.BytesToHash(hashBytes),
+			uuid.NewHash(sha256.New(), uuid.Nil, buf, 5),
+			nil
 	}
-	return common.BytesToHash(hashBytes),
-		uuid.NewHash(sha256.New(), uuid.Nil, buf, 5),
-		nil
+
+	if *b.Version == BundleVersionV2 {
+		// blockNumber, default 0
+		blockNumber := uint64(0)
+		if b.BlockNumber != nil {
+			blockNumber = uint64(*b.BlockNumber)
+		}
+
+		// minTimestamp, default 0
+		minTimestamp := uint64(0)
+		if b.MinTimestamp != nil {
+			minTimestamp = *b.MinTimestamp
+		}
+
+		// maxTimestamp, default ^uint64(0) (i.e. 0xFFFFFFFFFFFFFFFF in Rust)
+		maxTimestamp := ^uint64(0)
+		if b.MaxTimestamp != nil {
+			maxTimestamp = *b.MaxTimestamp
+		}
+
+		// Build up our buffer using variable-length encoding of the block
+		// number, minTimestamp, maxTimestamp, #revertingTxHashes, #droppingTxHashes.
+		var buf []byte
+		buf = binary.AppendUvarint(buf, blockNumber)
+		buf = binary.AppendUvarint(buf, minTimestamp)
+		buf = binary.AppendUvarint(buf, maxTimestamp)
+		buf = binary.AppendUvarint(buf, uint64(len(b.RevertingTxHashes)))
+		buf = binary.AppendUvarint(buf, uint64(len(b.DroppingTxHashes)))
+
+		// Append the main txs keccak hash (already computed in hashBytes).
+		buf = append(buf, hashBytes...)
+
+		// Sort revertingTxHashes and append them.
+		sort.Slice(b.RevertingTxHashes, func(i, j int) bool {
+			return bytes.Compare(b.RevertingTxHashes[i][:], b.RevertingTxHashes[j][:]) < 0
+		})
+		for _, h := range b.RevertingTxHashes {
+			buf = append(buf, h[:]...)
+		}
+
+		// Sort droppingTxHashes and append them.
+		sort.Slice(b.DroppingTxHashes, func(i, j int) bool {
+			return bytes.Compare(b.DroppingTxHashes[i][:], b.DroppingTxHashes[j][:]) < 0
+		})
+		for _, h := range b.DroppingTxHashes {
+			buf = append(buf, h[:]...)
+		}
+
+		// If a "refund" is present (analogous to the Rust code), we push:
+		//   refundPercent (1 byte)
+		//   refundRecipient (20 bytes, if an Ethereum address)
+		//   #refundTxHashes (varint)
+		//   each refundTxHash (32 bytes)
+		// NOTE: The Rust code uses a single byte for `refund.percent`,
+		//       so we do the same here. Adjust as needed if your data differs.
+		if b.RefundPercent != nil && b.RefundRecipient != nil && len(b.RefundTxHashes) > 0 {
+			// We only keep the low 8 bits of RefundPercent (mimicking Rust's `buff.push(u8)`).
+			buf = append(buf, byte(*b.RefundPercent))
+
+			// RefundRecipient is a common.Address, which is 20 bytes in geth.
+			buf = append(buf, b.RefundRecipient[:]...)
+
+			// Sort the refund tx hashes if needed. If these are strings with hex “0x...”,
+			// decode to []byte first. For example:
+			sort.Strings(b.RefundTxHashes)
+
+			// #refundTxHashes
+			buf = binary.AppendUvarint(buf, uint64(len(b.RefundTxHashes)))
+
+			// Each refundTxHash, appended as 32 raw bytes
+			for _, rth := range b.RefundTxHashes {
+				// decode from hex
+				decoded, err := hexutil.Decode(rth)
+				if err != nil {
+					return common.Hash{}, uuid.Nil, fmt.Errorf("invalid refundTxHash '%s': %w", rth, err)
+				}
+				if len(decoded) != 32 {
+					return common.Hash{}, uuid.Nil, fmt.Errorf("refundTxHash '%s' must be 32 bytes", rth)
+				}
+				buf = append(buf, decoded...)
+			}
+		}
+
+		// Now produce a UUID from `buf` using SHA-256 in the same way the Rust code calls
+		// `Self::uuid_from_buffer(buff)` (which is effectively a UUIDv5 but with SHA-256).
+		finalUUID := uuid.NewHash(sha256.New(), uuid.Nil, buf, 5)
+
+		// Return the main txs keccak hash as well as the computed UUID
+		return common.BytesToHash(hashBytes), finalUUID, nil
+	}
+
+	return common.Hash{}, uuid.Nil, ErrUnsupportedBundleVersion
+
 }
 
 func (b *MevSendBundleArgs) UniqueKey() uuid.UUID {

--- a/rpctypes/types_test.go
+++ b/rpctypes/types_test.go
@@ -87,6 +87,38 @@ func TestEthSendBundleArgsValidate(t *testing.T) {
 			ExpectedUUID:      "35718fe4-5d24-51c8-93bf-9c961d7c3ea3",
 			ExpectedUniqueKey: "3c718cb9-3f6c-5dc0-9d99-264dafc0b4e9",
 		},
+		{
+			Payload: []byte(`  {
+            "version": "v2",
+            "txs": [
+                "0x02f86b83aa36a780800982520894f24a01ae29dec4629dfb4170647c4ed4efc392cd861ca62a4c95b880c080a07d37bb5a4da153a6fbe24cf1f346ef35748003d1d0fc59cf6c17fb22d49e42cea02c231ac233220b494b1ad501c440c8b1a34535cdb8ca633992d6f35b14428672"
+            ],
+            "blockNumber": "0x0",
+            "minTimestamp": 123,
+            "maxTimestamp": 1234,
+            "revertingTxHashes": ["0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"],
+            "droppingTxHashes": ["0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"],
+            "refundPercent": 1,
+            "refundRecipient": "0x95222290dd7278aa3ddd389cc1e1d165cc4bafe5",
+            "refundTxHashes": ["0x75662ab9cb6d1be7334723db5587435616352c7e581a52867959ac24006ac1fe"]
+        }`),
+			ExpectedHash:      "0xee3996920364173b0990f92cf6fbeb8a4ab832fe5549c1b728ac44aee0160f02",
+			ExpectedUUID:      "e2bdb8cd-9473-5a1b-b425-57fa7ecfe2c1",
+			ExpectedUniqueKey: "a54c1e8f-936f-5868-bded-f5138c60b34a",
+		},
+		{
+			Payload: []byte(`{
+            "version": "v2",
+            "txs": [
+                "0x02f86b83aa36a780800982520894f24a01ae29dec4629dfb4170647c4ed4efc392cd861ca62a4c95b880c080a07d37bb5a4da153a6fbe24cf1f346ef35748003d1d0fc59cf6c17fb22d49e42cea02c231ac233220b494b1ad501c440c8b1a34535cdb8ca633992d6f35b14428672"
+            ],
+            "blockNumber": "0x0",
+            "revertingTxHashes": []
+        }`),
+			ExpectedHash:      "0xee3996920364173b0990f92cf6fbeb8a4ab832fe5549c1b728ac44aee0160f02",
+			ExpectedUUID:      "22dc6bf0-9a12-5a76-9bbd-98ab77423415",
+			ExpectedUniqueKey: "f61a2d65-d430-5369-9bff-0c44b5abc5a7",
+		},
 	}
 
 	for i, input := range inputs {


### PR DESCRIPTION
Extend (in a backwards compatible fashion) `bundle` model with `version` field. 
Support deterministic unique identifiers for such bundles