### PR TITLE
Add configurable timeouts to BlockSub

### DIFF
--- a/blocksub/blocksub.go
+++ b/blocksub/blocksub.go
@@ -15,6 +15,10 @@ import (
 )
 
 var ErrStopped = errors.New("already stopped")
+var (
+	defaultPollTimeout = 10 * time.Second
+	defaultSubTimeout  = 60 * time.Second
+)
 
 type BlockSubscriber interface {
 	IsRunning() bool
@@ -52,10 +56,14 @@ type BlockSub struct {
 }
 
 func NewBlockSub(ctx context.Context, ethNodeHTTPURI, ethNodeWebsocketURI string) *BlockSub {
+	return NewBlockSubWithTimeout(ctx, ethNodeHTTPURI, ethNodeWebsocketURI, defaultPollTimeout, defaultSubTimeout)
+}
+
+func NewBlockSubWithTimeout(ctx context.Context, ethNodeHTTPURI, ethNodeWebsocketURI string, pollTimeout, subTimeout time.Duration) *BlockSub {
 	ctx, cancel := context.WithCancel(ctx)
 	sub := &BlockSub{
-		PollTimeout:         10 * time.Second,
-		SubTimeout:          60 * time.Second,
+		PollTimeout:         pollTimeout,
+		SubTimeout:          subTimeout,
 		ethNodeHTTPURI:      ethNodeHTTPURI,
 		ethNodeWebsocketURI: ethNodeWebsocketURI,
 		ctx:                 ctx,


### PR DESCRIPTION
Small change needed for [lw-ofa](https://github.com/flashbots/lw-ofa-example).
Although we could have this in fork, I don't see any downside having this change here. It is useful for anyone who wants to use `go-utils` with L2s.
