### PR TITLE
fix: add defer body close cleanup to jsonrpc http post request

### DIFF
--- a/jsonrpc/request.go
+++ b/jsonrpc/request.go
@@ -37,6 +37,8 @@ func SendJSONRPCRequest(req JSONRPCRequest, url string) (res *JSONRPCResponse, e
 		return nil, err
 	}
 
+	defer rawResp.Body.Close()
+
 	res = new(JSONRPCResponse)
 	if err := json.NewDecoder(rawResp.Body).Decode(res); err != nil {
 		return nil, err


### PR DESCRIPTION
This cleans up [http's Body `io.ReadCloser`](https://pkg.go.dev/net/http#pkg-overview) after making a jsonrpc http post request.