### PR TITLE
fix: allow JSON-RPC error data in responses

### DIFF
--- a/rpcserver/jsonrpc_server.go
+++ b/rpcserver/jsonrpc_server.go
@@ -146,6 +146,14 @@ func (h *JSONRPCHandler) writeJSONRPCResponse(w http.ResponseWriter, response JS
 }
 
 func (h *JSONRPCHandler) writeJSONRPCError(w http.ResponseWriter, id any, code int, msg string) {
+	h.writeJSONRPCErrorWithData(w, id, code, msg, nil)
+}
+
+func (h *JSONRPCHandler) writeJSONRPCErrorWithData(w http.ResponseWriter, id any, code int, msg string, data any) {
+	var dataPtr *any
+	if data != nil {
+		dataPtr = &data
+	}
 	res := JSONRPCResponse{
 		JSONRPC: "2.0",
 		ID:      id,
@@ -153,7 +161,7 @@ func (h *JSONRPCHandler) writeJSONRPCError(w http.ResponseWriter, id any, code i
 		Error: &JSONRPCError{
 			Code:    code,
 			Message: msg,
-			Data:    nil,
+			Data:    dataPtr,
 		},
 	}
 	h.writeJSONRPCResponse(w, res)
@@ -324,7 +332,7 @@ func (h *JSONRPCHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	result, err := method.call(ctx, req.Params)
 	if err != nil {
 		if jsonRPCErr, ok := err.(*JSONRPCError); ok {
-			h.writeJSONRPCError(w, req.ID, jsonRPCErr.Code, jsonRPCErr.Message)
+			h.writeJSONRPCErrorWithData(w, req.ID, jsonRPCErr.Code, jsonRPCErr.Message, jsonRPCErr.Data)
 		} else {
 			h.writeJSONRPCError(w, req.ID, CodeCustomError, err.Error())
 		}


### PR DESCRIPTION
Passes JSON-RPC error `Data` through server responses when a method returns it.

Adds a new method `writeJSONRPCErrorWithData`.

Alternatives:
This is simpler than changing `writeJSONRPCError` everywhere and passing Data as `nil`.