### PR TITLE
rpcserver: add WithOrigin for middleware integration

### DIFF
--- a/rpcserver/jsonrpc_server.go
+++ b/rpcserver/jsonrpc_server.go
@@ -450,6 +450,13 @@ func GetOrigin(ctx context.Context) string {
 	return value
 }
 
+// WithOrigin returns a new request with the origin set in its context.
+// Use this in middleware to set the origin for downstream handlers to read via GetOrigin.
+func WithOrigin(r *http.Request, origin string) *http.Request {
+	ctx := context.WithValue(r.Context(), originKey{}, origin)
+	return r.WithContext(ctx)
+}
+
 func GetRequestSize(ctx context.Context) int {
 	return ctx.Value(sizeKey{}).(int)
 }


### PR DESCRIPTION
## Summary
- Adds `WithOrigin(r *http.Request, origin string) *http.Request`
- Symmetric with existing `GetOrigin(ctx)` - completes the API

## Motivation
Middleware that validates API keys and derives origin programmatically needs a way to set origin in the request context. Previously, the only option was to set an HTTP header and rely on `ExtractOriginFromHeader`, which conflates internal context passing with external headers.

## Usage
```go
func authMiddleware(next http.Handler) http.Handler {
    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
        origin := validateAPIKey(r.Header.Get("X-API-Key"))
        r = rpcserver.WithOrigin(r, origin)
        next.ServeHTTP(w, r)
    })
}
```

🤖 Generated with [Claude Code](https://claude.com/code)